### PR TITLE
Adoniyas/quotation request fixes

### DIFF
--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -1,11 +1,6 @@
 class VehiclesController < ApplicationController
   include Common
   def model_params
-    params.require(:payload).permit(
-      :make, :model, :year_of_manufacture, :estimated_value, :plate_number,
-      :chassis_number, :engine_number, :front_view_photo, :back_view_photo,
-      :left_view_photo, :right_view_photo, :engine_photo,
-      :chassis_number_photo, :libre_photo
-    )
+    params.require(:payload).permit(*Vehicle.permitted_params, *Vehicle.file_attachments)
   end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,4 +1,15 @@
 class Customer < ApplicationRecord
   belongs_to :user
+  has_many :residence_addresses, dependent: :destroy
+  has_one :current_address, -> { where(is_current: true) },
+          class_name: "ResidenceAddress"
+
   validates :first_name, :middle_name, :last_name, :birthdate, :gender, :region, :subcity, :woreda, presence: true
+
+  def add_residence_address(address_params)
+    transaction do
+      residence_addresses.where(is_current: true).update_all(is_current: false)
+      residence_addresses.create!(address_params.merge(is_current: true))
+    end
+  end
 end

--- a/app/models/insured_entity.rb
+++ b/app/models/insured_entity.rb
@@ -4,6 +4,7 @@ class InsuredEntity < ApplicationRecord
   belongs_to :entity_type
   belongs_to :entity, polymorphic: true
   has_many :policies, dependent: :destroy
+  has_many :quotation_requests
 
   validates :entity_id, uniqueness: { scope: [ :entity_type_id, :user_id ] }
   validate :entity_type_matches_entity

--- a/app/models/quotation_request.rb
+++ b/app/models/quotation_request.rb
@@ -2,8 +2,7 @@ class QuotationRequest < ApplicationRecord
   belongs_to :user
   belongs_to :insurance_product, optional: true
   belongs_to :coverage_type
-  belongs_to :vehicle
-  accepts_nested_attributes_for :vehicle
+  belongs_to :insured_entity
 
   validates :status, presence: true
   validates :form_data, presence: true

--- a/app/models/quotation_request.rb
+++ b/app/models/quotation_request.rb
@@ -5,5 +5,4 @@ class QuotationRequest < ApplicationRecord
   belongs_to :insured_entity
 
   validates :status, presence: true
-  validates :form_data, presence: true
 end

--- a/app/models/residence_address.rb
+++ b/app/models/residence_address.rb
@@ -1,0 +1,9 @@
+class ResidenceAddress < ApplicationRecord
+  belongs_to :customer
+
+  validates :region, :subcity, :woreda, :zone, presence: true
+  validates :is_current, uniqueness: { scope: :customer_id }, if: :is_current?
+
+  scope :current, -> { where(is_current: true) }
+  scope :previous, -> { where(is_current: false) }
+end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -35,6 +35,20 @@ class Vehicle < ApplicationRecord
   scope :newest_first, -> { order(created_at: :desc) }
   scope :most_valuable_first, -> { order(estimated_value: :desc) }
 
+  def self.permitted_params
+    [
+      :make, :model, :year_of_manufacture, :estimated_value, :plate_number,
+      :chassis_number, :engine_number, :vehicle_type, :usage_type,
+      { additional_fields: {} }
+    ]
+  end
+
+  def self.file_attachments
+    [
+      :front_view_photo, :back_view_photo, :left_view_photo, :right_view_photo,
+      :engine_photo, :chassis_number_photo, :libre_photo
+    ]
+  end
 
   def full_name
     "#{make} #{model} (#{year_of_manufacture})"
@@ -92,5 +106,4 @@ class Vehicle < ApplicationRecord
     if year_of_manufacture.present? && year_of_manufacture < 1950
       errors.add(:year_of_manufacture, "is too old")
     end
-  end
-end
+  enend

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -106,4 +106,5 @@ class Vehicle < ApplicationRecord
     if year_of_manufacture.present? && year_of_manufacture < 1950
       errors.add(:year_of_manufacture, "is too old")
     end
-  enend
+  end
+end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -2,7 +2,6 @@ class Vehicle < ApplicationRecord
   has_one :insured_entity, as: :entity
   has_many :entity_categories, as: :entity
   has_many :entity_attributes, as: :entity
-  has_many :quotation_requests
 
   has_one_attached :front_view_photo
   has_one_attached :back_view_photo
@@ -23,6 +22,8 @@ class Vehicle < ApplicationRecord
   validates :make, presence: true
   validates :model, presence: true
   validates :estimated_value, presence: true, numericality: { greater_than: 0 }
+  validates :vehicle_type, presence: true
+  validates :usage_type, presence: true
 
   validate :year_not_in_future
   validate :year_not_too_old
@@ -33,6 +34,7 @@ class Vehicle < ApplicationRecord
   scope :by_value_range, ->(min_value, max_value) { where(estimated_value: min_value..max_value) }
   scope :newest_first, -> { order(created_at: :desc) }
   scope :most_valuable_first, -> { order(estimated_value: :desc) }
+
 
   def full_name
     "#{make} #{model} (#{year_of_manufacture})"

--- a/app/models/vehicle_type_configuration.rb
+++ b/app/models/vehicle_type_configuration.rb
@@ -1,0 +1,5 @@
+class VehicleTypeConfiguration < ApplicationRecord
+  validates :vehicle_type, :usage_type, presence: true
+  validates :vehicle_type, uniqueness: { scope: :usage_type }
+  validates :expected_fields, presence: true
+end

--- a/app/policies/quotation_request_policy.rb
+++ b/app/policies/quotation_request_policy.rb
@@ -10,6 +10,10 @@ class QuotationRequestPolicy
     def resolve
       if user.has_role?("admin")
         scope.all
+      elsif user.insurer.present?
+        insurer_id = user.insurer.id
+        scope.joins(:insurance_product)
+             .where(insurance_products: { insurer_id: insurer_id })
       else
         scope.where(user_id: user.id)
       end

--- a/app/serializers/insurer_serializer.rb
+++ b/app/serializers/insurer_serializer.rb
@@ -2,6 +2,7 @@ class InsurerSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
 
   attributes :id, :name, :description, :contact_email, :contact_phone, :api_endpoint, :api_key, :logo_url
+  belongs_to :user
 
   def logo_url
     object.logo.attached? ? url_for(object.logo) : nil

--- a/app/serializers/quotation_request_serializer.rb
+++ b/app/serializers/quotation_request_serializer.rb
@@ -4,4 +4,12 @@ class QuotationRequestSerializer < ActiveModel::Serializer
   belongs_to :insurance_product
   belongs_to :coverage_type
   belongs_to :vehicle
+
+  def insurance_product
+    object.insurance_product.as_json(include: :insurer) if object.insurance_product
+  end
+
+  def coverage_type
+    object.coverage_type.as_json(include: :insurance_type) if object.coverage_type
+  end
 end

--- a/app/serializers/quotation_request_serializer.rb
+++ b/app/serializers/quotation_request_serializer.rb
@@ -1,9 +1,10 @@
 class QuotationRequestSerializer < ActiveModel::Serializer
-  attributes :id, :status, :form_data, :created_at, :updated_at
+  attributes :id, :status, :form_data, :created_at, :updated_at, :insured_entity_data
+
   belongs_to :user
   belongs_to :insurance_product
   belongs_to :coverage_type
-  belongs_to :vehicle
+  belongs_to :insured_entity
 
   def insurance_product
     object.insurance_product.as_json(include: :insurer) if object.insurance_product
@@ -11,5 +12,30 @@ class QuotationRequestSerializer < ActiveModel::Serializer
 
   def coverage_type
     object.coverage_type.as_json(include: :insurance_type) if object.coverage_type
+  end
+
+  def user
+    if object.user
+      user_data = object.user.as_json
+      user_data["customer"] = object.user.customer.as_json if object.user.customer
+      user_data
+    end
+  end
+
+  # This method will include the polymorphic entity's attributes
+  def insured_entity_data
+    entity = object.insured_entity&.entity
+    return nil unless entity
+
+    # Convention: Vehicle model maps to VehicleSerializer
+    serializer_class_name = "#{entity.class.name}Serializer"
+
+    begin
+      serializer_class = serializer_class_name.constantize
+      serializer_class.new(entity, scope: scope, root: false).as_json
+    rescue NameError
+      # Fallback if a specific serializer doesn't exist
+      entity.as_json
+    end
   end
 end

--- a/app/services/quotation_request_creator.rb
+++ b/app/services/quotation_request_creator.rb
@@ -1,0 +1,95 @@
+class QuotationRequestCreator
+  def initialize(user:, entity_class:, entity_params:, file_params:, quotation_params:, residence_address_params: nil)
+    @user = user
+    @entity_class = entity_class
+    @entity_params = entity_params
+    @file_params = file_params
+    @quotation_params = quotation_params
+    @residence_address_params = residence_address_params
+    @errors = []
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      ensure_customer_exists
+      handle_residence_address if @residence_address_params.present?
+
+      build_entity
+      attach_files if @file_params.present?
+
+      unless @entity.save
+        @errors.concat(@entity.errors.full_messages)
+        raise ActiveRecord::Rollback
+      end
+
+      build_insured_entity
+      unless @insured_entity.save
+        @errors.concat(@insured_entity.errors.full_messages)
+        raise ActiveRecord::Rollback
+      end
+
+      build_quotation_request
+      unless @quotation_request.save
+        @errors.concat(@quotation_request.errors.full_messages)
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    @quotation_request if @errors.empty?
+  end
+
+  def errors
+    @errors
+  end
+
+  private
+
+  def ensure_customer_exists
+    @customer = @user.customer
+    unless @customer
+      @errors << "User must have a customer profile"
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  def handle_residence_address
+    begin
+      @customer.add_residence_address(@residence_address_params)
+    rescue ActiveRecord::RecordInvalid => e
+      @errors.concat(e.record.errors.full_messages)
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  def build_entity
+    @entity = @entity_class.new(@entity_params)
+  end
+
+  def attach_files
+    @entity_class.file_attachments.each do |attachment_name|
+      if @file_params[attachment_name].present?
+        @entity.public_send(attachment_name).attach(@file_params[attachment_name])
+      end
+    end
+  end
+
+  def build_insured_entity
+    @insured_entity = InsuredEntity.new(
+      user: @user,
+      insurance_type: CoverageType.find_by(id: @quotation_params[:coverage_type_id])&.insurance_type,
+      entity: @entity,
+      entity_type: EntityType.find_by!(name: @entity_class.name)
+    )
+  end
+
+  def build_quotation_request
+    @quotation_request = QuotationRequest.new(
+      user: @user,
+      insured_entity: @insured_entity,
+      coverage_type_id: @quotation_params[:coverage_type_id],
+      insurance_product_id: @quotation_params[:insurance_product_id],
+      form_data: @quotation_params[:form_data] || {},
+      status: "pending"
+    )
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV.fetch("FRONTEND_URL")
+    origins ENV.fetch("FRONTEND_URLS").split(",").map(&:strip)
 
     resource "*",
       headers: :any,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@ en:
   auth:
     success:
       password_changed: "Password changed successfully. Please login again."
+      temporary_password_changed: "Temporary password changed successfully."
       logged_out: "Successfully logged out"
       logged_out_all: "Successfully logged out from all devices"
       email_verified: "Email verified successfully"

--- a/db/migrate/20250618092330_update_quotation_requests_for_insured_entities.rb
+++ b/db/migrate/20250618092330_update_quotation_requests_for_insured_entities.rb
@@ -1,0 +1,8 @@
+class UpdateQuotationRequestsForInsuredEntities < ActiveRecord::Migration[8.0]
+  def change
+    remove_foreign_key :quotation_requests, :vehicles
+    remove_column :quotation_requests, :vehicle_id, :bigint
+
+    add_reference :quotation_requests, :insured_entity, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20250618095339_add_fields_to_vehicles.rb
+++ b/db/migrate/20250618095339_add_fields_to_vehicles.rb
@@ -1,0 +1,10 @@
+class AddFieldsToVehicles < ActiveRecord::Migration[8.0]
+  def change
+    add_column :vehicles, :vehicle_type, :string, null: false
+    add_column :vehicles, :usage_type, :string, null: false
+    add_column :vehicles, :additional_fields, :jsonb, default: {}, null: false
+
+    add_index :vehicles, :vehicle_type
+    add_index :vehicles, :usage_type
+  end
+end

--- a/db/migrate/20250618105427_create_vehicle_type_configurations.rb
+++ b/db/migrate/20250618105427_create_vehicle_type_configurations.rb
@@ -1,0 +1,12 @@
+class CreateVehicleTypeConfigurations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :vehicle_type_configurations do |t|
+      t.string :vehicle_type, null: false
+      t.string :usage_type, null: false
+      t.jsonb :expected_fields, null: false, default: []
+
+      t.timestamps
+    end
+    add_index :vehicle_type_configurations, [ :vehicle_type, :usage_type ], unique: true
+  end
+end

--- a/db/migrate/20250622180456_create_residence_addresses.rb
+++ b/db/migrate/20250622180456_create_residence_addresses.rb
@@ -1,0 +1,16 @@
+class CreateResidenceAddresses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :residence_addresses do |t|
+      t.references :customer, null: false, foreign_key: true
+      t.string :region, null: false
+      t.string :subcity, null: false
+      t.string :woreda, null: false
+      t.string :zone, null: false
+      t.string :house_number
+      t.boolean :is_current, null: false, default: false
+
+      t.timestamps
+    end
+    add_index :residence_addresses, [ :customer_id, :is_current ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_18_105427) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_22_180456) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -304,6 +304,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_18_105427) do
     t.index ["user_id"], name: "index_refresh_tokens_on_user_id"
   end
 
+  create_table "residence_addresses", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.string "region", null: false
+    t.string "subcity", null: false
+    t.string "woreda", null: false
+    t.string "zone", null: false
+    t.string "house_number"
+    t.boolean "is_current", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id", "is_current"], name: "index_residence_addresses_on_customer_id_and_is_current"
+    t.index ["customer_id"], name: "index_residence_addresses_on_customer_id"
+  end
+
   create_table "role_permissions", force: :cascade do |t|
     t.bigint "role_id", null: false
     t.bigint "permission_id", null: false
@@ -417,6 +431,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_18_105427) do
   add_foreign_key "quotation_requests", "insured_entities"
   add_foreign_key "quotation_requests", "users"
   add_foreign_key "refresh_tokens", "users"
+  add_foreign_key "residence_addresses", "customers"
   add_foreign_key "role_permissions", "permissions"
   add_foreign_key "role_permissions", "roles"
   add_foreign_key "user_roles", "roles"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_11_112137) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_18_105427) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -279,16 +279,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_11_112137) do
   create_table "quotation_requests", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "coverage_type_id", null: false
-    t.bigint "vehicle_id", null: false
     t.string "status", default: "draft", null: false
     t.jsonb "form_data", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "insurance_product_id"
+    t.bigint "insured_entity_id", null: false
     t.index ["coverage_type_id"], name: "index_quotation_requests_on_coverage_type_id"
     t.index ["insurance_product_id"], name: "index_quotation_requests_on_insurance_product_id"
+    t.index ["insured_entity_id"], name: "index_quotation_requests_on_insured_entity_id"
     t.index ["user_id"], name: "index_quotation_requests_on_user_id"
-    t.index ["vehicle_id"], name: "index_quotation_requests_on_vehicle_id"
   end
 
   create_table "refresh_tokens", force: :cascade do |t|
@@ -345,6 +345,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_11_112137) do
     t.index ["phone_number"], name: "index_users_on_phone_number", unique: true
   end
 
+  create_table "vehicle_type_configurations", force: :cascade do |t|
+    t.string "vehicle_type", null: false
+    t.string "usage_type", null: false
+    t.jsonb "expected_fields", default: [], null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["vehicle_type", "usage_type"], name: "idx_on_vehicle_type_usage_type_6402aedbda", unique: true
+  end
+
   create_table "vehicles", force: :cascade do |t|
     t.string "plate_number"
     t.string "chassis_number"
@@ -355,9 +364,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_11_112137) do
     t.decimal "estimated_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "vehicle_type", null: false
+    t.string "usage_type", null: false
+    t.jsonb "additional_fields", default: {}, null: false
     t.index ["chassis_number"], name: "index_vehicles_on_chassis_number", unique: true
     t.index ["engine_number"], name: "index_vehicles_on_engine_number", unique: true
     t.index ["plate_number"], name: "index_vehicles_on_plate_number", unique: true
+    t.index ["usage_type"], name: "index_vehicles_on_usage_type"
+    t.index ["vehicle_type"], name: "index_vehicles_on_vehicle_type"
   end
 
   create_table "verification_tokens", force: :cascade do |t|
@@ -400,8 +414,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_11_112137) do
   add_foreign_key "premium_rates", "insurance_types"
   add_foreign_key "quotation_requests", "coverage_types"
   add_foreign_key "quotation_requests", "insurance_products"
+  add_foreign_key "quotation_requests", "insured_entities"
   add_foreign_key "quotation_requests", "users"
-  add_foreign_key "quotation_requests", "vehicles"
   add_foreign_key "refresh_tokens", "users"
   add_foreign_key "role_permissions", "permissions"
   add_foreign_key "role_permissions", "roles"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -144,6 +144,9 @@ vehicle = Vehicle.find_or_create_by!(plate_number: 'A12345') do |v|
   v.make = 'Toyota'
   v.model = 'Corolla'
   v.estimated_value = 1_500_000.00
+  v.vehicle_type = 'Private Vehicle'
+  v.usage_type = 'Private Own Use'
+  v.additional_fields = {}
 end
 
 customer_user = User.find_by!(email: 'customer@example.com')

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -8,6 +8,19 @@ FactoryBot.define do
     gender { [ 'Male', 'Female' ].sample }
     region { Faker::Address.state }
     subcity { Faker::Address.city }
-    woreda { Faker::Address.street_name }
+    woreda { Faker::Address.community }
+
+    trait :with_current_address do
+      after(:create) do |customer|
+        create(:residence_address, :current, customer: customer)
+      end
+    end
+
+    trait :with_multiple_addresses do
+      after(:create) do |customer|
+        create_list(:residence_address, 2, customer: customer, is_current: false)
+        create(:residence_address, :current, customer: customer)
+      end
+    end
   end
 end

--- a/spec/factories/quotation_requests.rb
+++ b/spec/factories/quotation_requests.rb
@@ -1,10 +1,34 @@
 FactoryBot.define do
   factory :quotation_request do
-    association :user
-    association :insurance_product
+    user
     association :coverage_type
-    association :insured_entity
-    status { 'pending' }
-    form_data { { example_key: "example_value" } }
+    association :insurance_product
+    form_data { { "additional_info" => Faker::Lorem.sentence } }
+    status { "pending" }
+
+    after(:build) do |quotation_request|
+      entity_type = EntityType.find_or_create_by(name: 'Vehicle')
+
+      vehicle = build(:vehicle)
+
+      create(:customer, user: quotation_request.user) unless quotation_request.user.customer
+
+      insured_entity = build(:insured_entity,
+        user: quotation_request.user,
+        entity: vehicle,
+        entity_type: entity_type,
+        insurance_type: quotation_request.coverage_type.insurance_type
+      )
+
+      quotation_request.insured_entity = insured_entity
+    end
+
+    trait :approved do
+      status { "approved" }
+    end
+
+    trait :rejected do
+      status { "rejected" }
+    end
   end
 end

--- a/spec/factories/quotation_requests.rb
+++ b/spec/factories/quotation_requests.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     association :user
     association :insurance_product
     association :coverage_type
-    association :vehicle
-    status { "draft" }
+    association :insured_entity
+    status { 'pending' }
     form_data { { example_key: "example_value" } }
   end
 end

--- a/spec/factories/residence_addresses.rb
+++ b/spec/factories/residence_addresses.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :residence_address do
+    association :customer
+    region { Faker::Address.state }
+    subcity { Faker::Address.city }
+    woreda { Faker::Number.number(digits: 2).to_s }
+    zone { "#{subcity} Zone #{Faker::Number.between(from: 1, to: 5)}" }
+    house_number { Faker::Address.building_number }
+    is_current { false }
+
+    trait :current do
+      is_current { true }
+    end
+
+    trait :previous do
+      is_current { false }
+    end
+  end
+end

--- a/spec/factories/vehicle_type_configurations.rb
+++ b/spec/factories/vehicle_type_configurations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :vehicle_type_configuration do
+    vehicle_type { [ 'Private Vehicle', 'Commercial Vehicle', 'Motorcycle' ].sample }
+    usage_type { [ 'Private Own Use', 'Commercial Own Goods', 'Hire and Reward' ].sample }
+    expected_fields { { color: 'string', doors: 'integer' }.to_json }
+  end
+end

--- a/spec/factories/vehicles.rb
+++ b/spec/factories/vehicles.rb
@@ -7,6 +7,9 @@ FactoryBot.define do
     make { [ 'Toyota', 'Honda', 'Ford', 'BMW' ].sample }
     model { [ 'Corolla', 'Civic', 'Focus', '3 Series' ].sample }
     estimated_value { rand(500_000..2_000_000.0).round(2) }
+    vehicle_type { 'Private Vehicle' }
+    usage_type { 'Private Own Use' }
+    additional_fields { {} }
 
     created_at { Time.now }
     updated_at { Time.now }

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1,15 +1,94 @@
 require 'rails_helper'
 
 RSpec.describe Customer, type: :model do
-  include_examples "model_shared_spec", :customer, [
-    { first_name: :presence },
-    { middle_name: :presence },
-    { last_name: :presence },
-    { birthdate: :presence },
-    { gender: :presence },
-    { region: :presence },
-    { subcity: :presence },
-    { woreda: :presence },
-    { user: :belong_to }
+  attributes = [
+    { user: [ :belong_to ] },
+    { residence_addresses: [ :have_many ] },
+    { current_address: [ :have_one ] },
+    { first_name: [ :presence ] },
+    { middle_name: [ :presence ] },
+    { last_name: [ :presence ] },
+    { birthdate: [ :presence ] },
+    { gender: [ :presence ] },
+    { region: [ :presence ] },
+    { subcity: [ :presence ] },
+    { woreda: [ :presence ] }
   ]
+
+  include_examples "model_shared_spec", :customer, attributes
+
+  describe 'associations' do
+    it 'destroys dependent residence_addresses when customer is destroyed' do
+      customer = create(:customer, :with_multiple_addresses)
+      address_ids = customer.residence_addresses.pluck(:id)
+
+      expect { customer.destroy }.to change(ResidenceAddress, :count).by(-3)
+      expect(ResidenceAddress.where(id: address_ids)).to be_empty
+    end
+
+    it 'returns the current address correctly' do
+      customer = create(:customer, :with_current_address)
+      current_address = customer.residence_addresses.find_by(is_current: true)
+
+      expect(customer.current_address).to eq(current_address)
+      expect(customer.current_address.is_current).to be_truthy
+    end
+  end
+
+  describe '#add_residence_address' do
+    let(:customer) { create(:customer, :with_current_address) }
+    let(:new_address_params) do
+      {
+        region: 'New Region',
+        subcity: 'New Subcity',
+        woreda: 'New Woreda',
+        zone: 'New Zone'
+      }
+    end
+
+    it 'creates a new current address and marks old addresses as not current' do
+      expect {
+        customer.add_residence_address(new_address_params)
+      }.to change(customer.residence_addresses, :count).by(1)
+
+      customer.reload
+      expect(customer.residence_addresses.where(is_current: true).count).to eq(1)
+      expect(customer.current_address.region).to eq('New Region')
+      expect(customer.current_address.subcity).to eq('New Subcity')
+    end
+
+    it 'ensures only one current address exists' do
+      create(:residence_address, customer: customer, is_current: false)
+      customer.reload
+
+      customer.add_residence_address(new_address_params)
+      customer.reload
+
+      expect(customer.residence_addresses.where(is_current: true).count).to eq(1)
+      expect(customer.residence_addresses.where(is_current: false).count).to eq(2)
+    end
+
+    it 'handles transaction rollback on failure' do
+      allow(customer.residence_addresses).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+
+      expect {
+        customer.add_residence_address(new_address_params)
+      }.to raise_error(ActiveRecord::RecordInvalid)
+
+      customer.reload
+      expect(customer.residence_addresses.where(is_current: true).count).to eq(1)
+    end
+
+    it 'works when customer has no current address' do
+      customer_without_current = create(:customer)
+
+      expect {
+        customer_without_current.add_residence_address(new_address_params)
+      }.to change(customer_without_current.residence_addresses, :count).by(1)
+
+      customer_without_current.reload
+      expect(customer_without_current.current_address).to be_present
+      expect(customer_without_current.current_address.is_current).to be_truthy
+    end
+  end
 end

--- a/spec/models/quotation_request_spec.rb
+++ b/spec/models/quotation_request_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe QuotationRequest, type: :model do
     { insurance_product: [ { belong_to: { optional: true } } ] },
     { coverage_type: [ :belong_to ] },
     { status: [ :presence ] },
-    { form_data: [ :presence ] }
+    { form_data: [ :presence ] },
+    { insured_entity: [ :belong_to ] }
   ]
 
   include_examples "model_shared_spec", :quotation_request, attributes

--- a/spec/models/quotation_request_spec.rb
+++ b/spec/models/quotation_request_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe QuotationRequest, type: :model do
     { insurance_product: [ { belong_to: { optional: true } } ] },
     { coverage_type: [ :belong_to ] },
     { status: [ :presence ] },
-    { form_data: [ :presence ] },
     { insured_entity: [ :belong_to ] }
   ]
 

--- a/spec/models/residence_address_spec.rb
+++ b/spec/models/residence_address_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe ResidenceAddress, type: :model do
+  attributes = [
+    { customer: [ :belong_to ] },
+    { region: [ :presence ] },
+    { subcity: [ :presence ] },
+    { woreda: [ :presence ] },
+    { zone: [ :presence ] },
+    { is_current: [ { uniqueness: { scope: :customer_id } } ] }
+  ]
+
+  include_examples "model_shared_spec", :residence_address, attributes
+
+  describe 'validations' do
+    context 'is_current uniqueness' do
+      let(:customer) { create(:customer) }
+
+      it 'allows multiple addresses for same customer if only one is current' do
+        create(:residence_address, customer: customer, is_current: true)
+        address2 = build(:residence_address, customer: customer, is_current: false)
+        address3 = build(:residence_address, customer: customer, is_current: false)
+
+        expect(address2).to be_valid
+        expect(address3).to be_valid
+      end
+
+      it 'prevents multiple current addresses for same customer' do
+        create(:residence_address, customer: customer, is_current: true)
+        duplicate_current = build(:residence_address, customer: customer, is_current: true)
+
+        expect(duplicate_current).not_to be_valid
+        expect(duplicate_current.errors[:is_current]).to include('has already been taken')
+      end
+
+      it 'allows current addresses for different customers' do
+        customer2 = create(:customer)
+        create(:residence_address, customer: customer, is_current: true)
+        address_for_customer2 = build(:residence_address, customer: customer2, is_current: true)
+
+        expect(address_for_customer2).to be_valid
+      end
+
+      it 'allows validation to pass when is_current is false' do
+        create(:residence_address, customer: customer, is_current: true)
+        non_current_address = build(:residence_address, customer: customer, is_current: false)
+
+        expect(non_current_address).to be_valid
+      end
+    end
+
+    context 'conditional validation' do
+      it 'only validates uniqueness when is_current is true' do
+        customer = create(:customer)
+        create(:residence_address, customer: customer, is_current: false)
+        another_non_current = build(:residence_address, customer: customer, is_current: false)
+
+        expect(another_non_current).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Vehicle, type: :model do
 
     it 'filters by model year range' do
       expect(Vehicle.by_year_range(2009, 2015)).to include(@old)
-      expect(Vehicle.by_year_range(2009, 2015)).not_to include(@new)
+      expect(Vehicle.by_year_range(2009, 2014)).not_to include(@new)
     end
 
     it 'filters by value range' do

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe Vehicle, type: :model do
     { estimated_value: [ :presence, { numericality: { greater_than: 0 } } ] },
     { insured_entity: [ :have_one ] },
     { entity_categories: [ :have_many ] },
-    { entity_attributes: [ :have_many ] }
+    { entity_attributes: [ :have_many ] },
+    { vehicle_type: [ :presence ] },
+    { usage_type: [ :presence ] }
   ] + photo_attributes.map { |photo| { photo => photo_validations } }
   include_examples "model_shared_spec", :vehicle, attributes
 

--- a/spec/models/vehicle_type_configuration_spec.rb
+++ b/spec/models/vehicle_type_configuration_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe VehicleTypeConfiguration, type: :model do
+  attributes = [
+      { vehicle_type: [ :presence, { uniqueness: { scope: :usage_type } } ] },
+      { usage_type: [ :presence ] },
+      { expected_fields: [ :presence ] }
+  ]
+
+  include_examples 'model_shared_spec', :vehicle_type_configuration, attributes
+end

--- a/spec/requests/insurers_spec.rb
+++ b/spec/requests/insurers_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe InsurersController, type: :request do
     }
   end
 
-  include_examples 'request_shared_spec', 'insurers', 8
+  include_examples 'request_shared_spec', 'insurers', 9
 
   describe 'PUT /insurers/:id with logo' do
     let(:auth_user) { create(:user, :with_insurer) }

--- a/spec/requests/quotation_requests_spec.rb
+++ b/spec/requests/quotation_requests_spec.rb
@@ -1,150 +1,201 @@
 require 'rails_helper'
 
-RSpec.describe "QuotationRequests", type: :request do
-  let(:auth_user) { create(:user) }
-  let(:insurance_product) { create(:insurance_product) }
+RSpec.describe QuotationRequestsController, type: :request do
   let(:coverage_type) { create(:coverage_type) }
-
-  let(:file) { fixture_file_upload(Rails.root.join('spec/fixtures/files/sample_image.jpg'), 'image/jpeg') }
+  let(:insurance_product) { create(:insurance_product) }
+  let(:entity_type) { EntityType.find_or_create_by(name: 'Vehicle') }
 
   let(:valid_attributes) do
     {
-      user_id: auth_user.id,
-      insurance_product_id: insurance_product.id,
-      coverage_type_id: coverage_type.id,
-      status: "draft",
-      form_data: {
-        "insurance_type" => "Motor Insurance",
-        "coverage_type" => "Comprehensive"
-      },
-      vehicle_attributes: {
-        plate_number: "ABC1234",
-        chassis_number: "XYZ123456789",
-        engine_number: "ENG123456",
-        make: "Toyota",
-        model: "Corolla",
+      entity_type: 'Vehicle',
+      entity_data: {
+        make: 'Toyota',
+        model: 'Camry',
+        plate_number: 'ET312345',
         year_of_manufacture: 2020,
-        estimated_value: 150000
+        chassis_number: Faker::Vehicle.vin,
+        engine_number: Faker::Alphanumeric.alphanumeric(number: 10),
+        estimated_value: 500000,
+        vehicle_type: 'Sedan',
+        usage_type: 'Private',
+        additional_fields: {
+          color: 'Blue',
+          fuel_type: 'Gasoline'
+        }
+      },
+      coverage_type_id: coverage_type.id,
+      insurance_product_id: insurance_product.id,
+      form_data: {
+        additional_notes: 'Test quotation request'
       }
     }
   end
 
   let(:invalid_attributes) do
     {
-      user_id: nil,
+      entity_type: 'Vehicle',
+      entity_data: {
+        make: '',
+        model: '',
+        plate_number: '',
+        year_of_manufacture: nil,
+        estimated_value: nil,
+        vehicle_type: '',
+        usage_type: ''
+      },
       coverage_type_id: nil,
-      form_data: {}
+      insurance_product_id: nil
     }
   end
 
-  describe 'POST /create' do
-    it 'creates a new QuotationRequest with vehicle and image' do
-      expect {
-        post(
-          quotation_requests_url,
-          headers: { 'Authorization' => "Bearer #{auth_user.generate_access_token}" },
-          params: {
-            payload: valid_attributes.to_json,
-            'vehicle_attributes[front_view_photo]' => file
-          },
-          as: :multipart
+  let(:new_attributes) do
+    {
+      status: 'approved'
+    }
+  end
+
+  include_examples 'request_shared_spec', 'quotation_requests', 10, [ :create, :update ]
+
+  describe 'POST /quotation_requests' do
+    let(:auth_user) { create(:user, :with_customer) }
+    let(:token) { auth_user.generate_access_token }
+    let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+
+    before do
+      EntityType.find_or_create_by(name: 'Vehicle')
+
+      role = create(:role, name: 'customer')
+      auth_user.roles << role
+      permission = create(:permission, action: 'create', resource: 'quotation_requests')
+      role.permissions << permission
+    end
+
+    context 'with valid params' do
+      it 'creates a new quotation request' do
+        expect {
+          post quotation_requests_url, headers: headers, params: valid_attributes, as: :json
+        }.to change(QuotationRequest, :count).by(1)
+         .and change(Vehicle, :count).by(1)
+         .and change(InsuredEntity, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        result = JSON(response.body)
+        expect(result['success']).to be_truthy
+        expect(result['data']['status']).to eq('pending')
+      end
+
+      it 'creates quotation request with file attachments' do
+        file = fixture_file_upload(Rails.root.join('spec/fixtures/files/sample_image.jpg'), 'image/jpeg')
+        params = valid_attributes.deep_merge(
+          entity_data: {
+            files: { front_view_photo: file }
+          }
         )
-      }.to change(QuotationRequest, :count).by(1)
-        .and change(Vehicle, :count).by(1)
+        post quotation_requests_url, headers: headers, params: params
 
-      expect(response).to have_http_status(:created)
-      body = JSON.parse(response.body)
-      expect(body['success']).to be true
-      expect(body['data']['vehicle']['plate_number']).to eq("ABC1234")
-    end
+        expect(response).to have_http_status(:created)
+        result = JSON(response.body)
+        expect(result['success']).to be_truthy
 
-    it 'fails to create with invalid attributes' do
-      post(
-        quotation_requests_url,
-        headers: { 'Authorization' => "Bearer #{auth_user.generate_access_token}" },
-        params: {
-          payload: invalid_attributes.to_json
-        },
-        as: :multipart
-      )
+        vehicle = Vehicle.last
+        expect(vehicle.front_view_photo).to be_attached
+      end
 
-      expect(response).to have_http_status(:unprocessable_entity)
-      body = JSON.parse(response.body)
-      expect(body['success']).to be false
-    end
-  end
-
-  describe 'PUT /update' do
-    it 'updates an existing QuotationRequest' do
-      request = create(:quotation_request, user: auth_user, insurance_product: insurance_product, coverage_type: coverage_type)
-      update_data = {
-        form_data: {
-          "insurance_type" => "Updated Insurance",
-          "coverage_type" => "Updated Coverage"
+      it 'creates quotation request with residence address' do
+        residence_params = {
+          region: 'Addis Ababa',
+          subcity: 'Bole',
+          woreda: '03',
+          zone: 'Megenagna',
+          house_number: '123'
         }
-      }
 
-      put(
-        quotation_request_url(request),
-        headers: { 'Authorization' => "Bearer #{auth_user.generate_access_token}" },
-        params: {
-          id: request.id,
-          payload: update_data.to_json
-        },
-        as: :multipart
-      )
+        params = valid_attributes.merge(residence_address: residence_params)
 
-      expect(response).to have_http_status(:ok)
-      request.reload
-      expect(request.form_data["insurance_type"]).to eq("Updated Insurance")
+        expect {
+          post quotation_requests_url, headers: headers, params: params, as: :json
+        }.to change(ResidenceAddress, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        customer = auth_user.customer.reload
+        expect(customer.current_address.region).to eq('Addis Ababa')
+        expect(customer.current_address.subcity).to eq('Bole')
+      end
+
+      it 'updates existing current address when new residence address provided' do
+        create(:residence_address, :current, customer: auth_user.customer)
+
+        residence_params = {
+          region: 'Oromia',
+          subcity: 'Adama',
+          woreda: '01',
+          zone: 'Center'
+        }
+
+        params = valid_attributes.merge(residence_address: residence_params)
+
+        expect {
+          post quotation_requests_url, headers: headers, params: params, as: :json
+        }.to change(ResidenceAddress, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        customer = auth_user.customer.reload
+        expect(customer.current_address.region).to eq('Oromia')
+        expect(customer.residence_addresses.where(is_current: false).count).to eq(1)
+      end
     end
 
-    it 'fails to update with invalid data' do
-      request = create(:quotation_request, user: auth_user, insurance_product: insurance_product, coverage_type: coverage_type)
+    context 'with invalid params' do
+      it 'renders errors for invalid entity data' do
+        post quotation_requests_url, headers: headers, params: invalid_attributes, as: :json
 
-      put(
-        quotation_request_url(request),
-        headers: { 'Authorization' => "Bearer #{auth_user.generate_access_token}" },
-        params: {
-          id: request.id,
-          payload: invalid_attributes.to_json
-        },
-        as: :multipart
-      )
+        expect(response).to have_http_status(:unprocessable_entity)
+        result = JSON(response.body)
+        expect(result['success']).to be_falsey
+        expect(result['errors']).to be_present
+      end
 
-      expect(response).to have_http_status(:unprocessable_entity)
-      body = JSON.parse(response.body)
-      expect(body['success']).to be false
-    end
-  end
+      it 'handles unknown entity type' do
+        params = valid_attributes.merge(entity_type: 'UnknownEntity')
 
-  describe 'GET /index' do
-    it 'returns a list of quotation requests' do
-      create_list(:quotation_request, 3, user: auth_user, insurance_product: insurance_product, coverage_type: coverage_type)
+        post quotation_requests_url, headers: headers, params: params, as: :json
 
-      get(
-        quotation_requests_url,
-        headers: { 'Authorization' => "Bearer #{auth_user.generate_access_token}" }
-      )
+        expect(response).to have_http_status(:unprocessable_entity)
+        result = JSON(response.body)
+        expect(result['success']).to be_falsey
+        expect(result['error']).to include('Unknown entity type')
+      end
 
-      expect(response).to have_http_status(:ok)
-      body = JSON.parse(response.body)
-      expect(body['data'].length).to be >= 3
-    end
-  end
+      it 'handles user without customer profile' do
+        user_without_customer = create(:user)
+        token_without_customer = user_without_customer.generate_access_token
+        headers_without_customer = { 'Authorization' => "Bearer #{token_without_customer}" }
 
-  describe 'GET /show' do
-    it 'returns a single quotation request' do
-      request = create(:quotation_request, user: auth_user, insurance_product: insurance_product, coverage_type: coverage_type)
+        post quotation_requests_url, headers: headers_without_customer, params: valid_attributes, as: :json
 
-      get(
-        quotation_request_url(request),
-        headers: { 'Authorization' => "Bearer #{auth_user.generate_access_token}" }
-      )
+        expect(response).to have_http_status(:unprocessable_entity)
+        result = JSON(response.body)
+        expect(result['success']).to be_falsey
+        expect(result['errors']).to include('User must have a customer profile')
+      end
 
-      expect(response).to have_http_status(:ok)
-      body = JSON.parse(response.body)
-      expect(body['data']['id']).to eq(request.id)
+      it 'handles invalid residence address data' do
+        residence_params = {
+          region: '',
+          subcity: '',
+          woreda: ''
+        }
+
+        params = valid_attributes.merge(residence_address: residence_params)
+
+        post quotation_requests_url, headers: headers, params: params, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        result = JSON(response.body)
+        expect(result['success']).to be_falsey
+      end
     end
   end
 end

--- a/spec/requests/vehicles_spec.rb
+++ b/spec/requests/vehicles_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "Vehicles API", type: :request do
       plate_number: "ABC123",
       chassis_number: "CHASSIS123456",
       engine_number: "ENGINE123456",
+      vehicle_type: 'Private Vehicle',
+      usage_type: 'Private Own Use',
       front_view_photo: fixture_file_upload(Rails.root.join("spec/fixtures/files/sample_image.jpg"), "image/jpeg")
     }
   end

--- a/spec/services/quotation_request_creator_spec.rb
+++ b/spec/services/quotation_request_creator_spec.rb
@@ -1,0 +1,304 @@
+require 'rails_helper'
+
+RSpec.describe QuotationRequestCreator, type: :service do
+  let(:user) { create(:user, :with_customer) }
+  let(:coverage_type) { create(:coverage_type) }
+  let(:insurance_product) { create(:insurance_product) }
+  let!(:entity_type) { create(:entity_type, name: 'Vehicle') }
+
+  let(:entity_params) do
+    {
+      make: 'Toyota',
+      model: 'Camry',
+      year_of_manufacture: 2020,
+      plate_number: 'ABC123',
+      chassis_number: Faker::Vehicle.vin,
+      engine_number: Faker::Alphanumeric.alphanumeric(number: 10),
+      estimated_value: 500_000,
+      vehicle_type: 'Sedan',
+      usage_type: 'Private',
+      additional_fields: {
+        color: 'Blue',
+        fuel_type: 'Gasoline'
+      }
+    }
+  end
+
+  let(:quotation_params) do
+    {
+      coverage_type_id: coverage_type.id,
+      insurance_product_id: insurance_product.id,
+      form_data: { additional_notes: 'Test quotation' }
+    }
+  end
+
+  describe '#call' do
+    context 'with valid parameters' do
+      let(:service) do
+        described_class.new(
+          user: user,
+          entity_class: Vehicle,
+          entity_params: entity_params,
+          file_params: nil,
+          quotation_params: quotation_params
+        )
+      end
+
+      it 'creates a quotation request successfully' do
+        expect {
+          result = service.call
+          expect(result).to be_a(QuotationRequest)
+          expect(result).to be_persisted
+        }.to change(QuotationRequest, :count).by(1)
+         .and change(Vehicle, :count).by(1)
+         .and change(InsuredEntity, :count).by(1)
+      end
+
+      it 'sets correct attributes on quotation request' do
+        result = service.call
+
+        expect(result.user).to eq(user)
+        expect(result.status).to eq('pending')
+        expect(result.coverage_type).to eq(coverage_type)
+        expect(result.insurance_product).to eq(insurance_product)
+        expect(result.form_data).to eq({ 'additional_notes' => 'Test quotation' })
+      end
+
+      it 'creates associated vehicle with correct attributes' do
+        result = service.call
+        vehicle = result.insured_entity.entity
+
+        expect(vehicle).to be_a(Vehicle)
+        expect(vehicle.make).to eq('Toyota')
+        expect(vehicle.model).to eq('Camry')
+        expect(vehicle.year_of_manufacture).to eq(2020)
+      end
+
+      it 'creates insured entity with correct associations' do
+        result = service.call
+        insured_entity = result.insured_entity
+
+        expect(insured_entity.user).to eq(user)
+        expect(insured_entity.insurance_type).to eq(coverage_type.insurance_type)
+        expect(insured_entity.entity_type.name).to eq('Vehicle')
+      end
+    end
+
+    context 'with file attachments' do
+      let(:file) { fixture_file_upload(Rails.root.join('spec/fixtures/files/sample_image.jpg'), 'image/jpeg') }
+      let(:file_params) { { libre_photo: file } }
+
+      let(:service) do
+        described_class.new(
+          user: user,
+          entity_class: Vehicle,
+          entity_params: entity_params,
+          file_params: file_params,
+          quotation_params: quotation_params
+        )
+      end
+
+      it 'attaches files to the entity' do
+        result = service.call
+        vehicle = result.insured_entity.entity
+
+        expect(vehicle.libre_photo).to be_attached
+      end
+    end
+
+    context 'with residence address parameters' do
+      let(:residence_address_params) do
+        {
+          region: 'Addis Ababa',
+          subcity: 'Bole',
+          woreda: '03',
+          zone: 'Megenagna'
+        }
+      end
+
+      let(:service) do
+        described_class.new(
+          user: user,
+          entity_class: Vehicle,
+          entity_params: entity_params,
+          file_params: nil,
+          quotation_params: quotation_params,
+          residence_address_params: residence_address_params
+        )
+      end
+
+      it 'creates a new residence address' do
+        expect {
+          service.call
+        }.to change(ResidenceAddress, :count).by(1)
+
+        customer = user.customer.reload
+        expect(customer.current_address.region).to eq('Addis Ababa')
+        expect(customer.current_address.subcity).to eq('Bole')
+      end
+
+      it 'updates existing current address' do
+        create(:residence_address, :current, customer: user.customer)
+
+        expect {
+          service.call
+        }.to change(ResidenceAddress, :count).by(1)
+
+        customer = user.customer.reload
+        expect(customer.current_address.region).to eq('Addis Ababa')
+        expect(customer.residence_addresses.where(is_current: false).count).to eq(1)
+      end
+    end
+
+    context 'with invalid parameters' do
+      context 'when user has no customer profile' do
+        let(:user_without_customer) { create(:user) }
+
+        let(:service) do
+          described_class.new(
+            user: user_without_customer,
+            entity_class: Vehicle,
+            entity_params: entity_params,
+            file_params: nil,
+            quotation_params: quotation_params
+          )
+        end
+
+        it 'returns nil and sets error' do
+          result = service.call
+
+          expect(result).to be_nil
+          expect(service.errors).to include('User must have a customer profile')
+        end
+      end
+
+      context 'when entity validation fails' do
+        let(:invalid_entity_params) { entity_params.merge(make: '', model: '') }
+
+        let(:service) do
+          described_class.new(
+            user: user,
+            entity_class: Vehicle,
+            entity_params: invalid_entity_params,
+            file_params: nil,
+            quotation_params: quotation_params
+          )
+        end
+
+        it 'returns nil and sets errors' do
+          result = service.call
+
+          expect(result).to be_nil
+          expect(service.errors).to include("Make can't be blank")
+        end
+
+        it 'does not create any records' do
+          expect {
+            service.call
+          }.not_to(change { [ QuotationRequest.count, Vehicle.count, InsuredEntity.count ] })
+        end
+      end
+
+      context 'when residence address validation fails' do
+        let(:invalid_residence_params) do
+          {
+            region: '',
+            subcity: '',
+            woreda: ''
+          }
+        end
+
+        let(:service) do
+          described_class.new(
+            user: user,
+            entity_class: Vehicle,
+            entity_params: entity_params,
+            file_params: nil,
+            quotation_params: quotation_params,
+            residence_address_params: invalid_residence_params
+          )
+        end
+
+        it 'returns nil and sets errors' do
+          result = service.call
+
+          expect(result).to be_nil
+          expect(service.errors).to include("Region can't be blank")
+        end
+      end
+
+      context 'when quotation request validation fails' do
+        let(:invalid_quotation_params) do
+          {
+            coverage_type_id: nil,
+            insurance_product_id: nil,
+            form_data: {}
+          }
+        end
+
+        let(:service) do
+          described_class.new(
+            user: user,
+            entity_class: Vehicle,
+            entity_params: entity_params,
+            file_params: nil,
+            quotation_params: invalid_quotation_params
+          )
+        end
+
+        it 'returns nil and sets errors' do
+          result = service.call
+
+          expect(result).to be_nil
+          expect(service.errors).not_to be_empty
+        end
+      end
+    end
+
+    context 'transaction rollback' do
+      let(:service) do
+        described_class.new(
+          user: user,
+          entity_class: Vehicle,
+          entity_params: entity_params,
+          file_params: nil,
+          quotation_params: quotation_params
+        )
+      end
+
+      it 'rolls back all changes when an error occurs' do
+        allow_any_instance_of(QuotationRequest).to receive(:save).and_return(false)
+        allow_any_instance_of(QuotationRequest).to receive(:errors).and_return(
+          double(full_messages: [ 'Some validation error' ])
+        )
+
+        expect {
+          service.call
+        }.not_to(change { [ Vehicle.count, InsuredEntity.count, QuotationRequest.count ] })
+
+        expect(service.errors).to include('Some validation error')
+      end
+    end
+  end
+
+  describe '#errors' do
+    let(:service) do
+      described_class.new(
+        user: create(:user), # User without customer
+        entity_class: Vehicle,
+        entity_params: entity_params,
+        file_params: nil,
+        quotation_params: quotation_params
+      )
+    end
+
+    it 'returns empty array initially' do
+      expect(service.errors).to eq([])
+    end
+
+    it 'accumulates errors during execution' do
+      service.call
+      expect(service.errors).not_to be_empty
+    end
+  end
+end

--- a/spec/support/requests/shared_examples.rb
+++ b/spec/support/requests/shared_examples.rb
@@ -23,7 +23,11 @@ RSpec.shared_examples 'request_shared_spec' do |controller, field_count, exclude
     describe 'GET /index' do
       it 'returns success response' do
         count = clazz.count
-        3.times { create(factory) }
+        if clazz.reflect_on_association(:user)
+          3.times { create(factory, user: auth_user) }
+        else
+          3.times { create(factory) }
+        end
         get(send(:"#{controller}_url"), headers:, as: :json)
         expect(response).to be_successful
         result = JSON(response.body)


### PR DESCRIPTION
Added changes to the application’s handling of insured entities, vehicles, residence addresses, and quotation requests, along with improvements to serializers and policies. Key updates include replacing the vehicle association with a polymorphic insured entity in the QuotationRequest model, updating the database schema, and adding a new QuotationRequestCreator service to handle the creation of related entities. The Vehicle model now includes new attributes for vehicle_type and usage_type, with corresponding migrations to add these fields and a new vehicle_type_configurations table. For residence addresses, a new ResidenceAddress model and associated migrations were introduced, allowing customers to manage current and previous addresses. Serializers were enhanced to include polymorphic entity data and nested relationships, while the QuotationRequestPolicy was updated to filter requests based on the insurer's association. Lastly, CORS configurations were updated to support multiple frontend URLs, and a new localization string was added for temporary password changes.

